### PR TITLE
Mccalluc/special hubmap restrictions

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 100

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 schema-cache
 
 ## Defaults from github below:

--- a/hubmap-schema.json
+++ b/hubmap-schema.json
@@ -12,6 +12,19 @@
         "schema_type": {"enum": ["file"]},
         "describedBy": {"enum": ["https://schema.humancellatlas.org/type/file/2.2.0/supplementary_file"]}
       }
+    },
+    {
+      "properties": {
+        "schema_type": {"enum": ["biomaterial"]},
+        "describedBy": {"enum": ["https://schema.humancellatlas.org/type/biomaterial/5.1.0/donor_organism",
+                                 "https://schema.humancellatlas.org/type/biomaterial/5.1.0/specimen_from_organism"]}
+      }
+    },
+    {
+      "properties": {
+        "schema_type": {"enum": ["protocol"]},
+        "describedBy": {"enum": ["https://schema.humancellatlas.org/type/protocol/5.1.0/protocol"]}
+      }
     }
   ]
 }

--- a/hubmap-schema.json
+++ b/hubmap-schema.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "oneOf": [
+    {
+      "properties": {
+        "schema_type": {"enum": ["process"]},
+        "describedBy": {"enum": ["https://schema.humancellatlas.org/type/process/biomaterial_collection/5.1.0/collection_process"]}
+      }
+    },
+    {
+      "properties": {
+        "schema_type": {"enum": ["file"]},
+        "describedBy": {"enum": ["https://schema.humancellatlas.org/type/file/2.2.0/supplementary_file"]}
+      }
+    }
+  ]
+}

--- a/test.py
+++ b/test.py
@@ -4,6 +4,7 @@ import os
 import json
 from urllib.parse import urlparse
 from collections import defaultdict
+from pprint import PrettyPrinter
 
 import wget
 from jsonschema import validate
@@ -21,7 +22,7 @@ def download_to(url, target):
 def main():
     fails = defaultdict(dict)
     hubmap_schema = json.load(open('hubmap-schema.json'))
-    
+
     for dir_path, _, file_names in os.walk('workflows'):
         for name in file_names:
             path = os.path.join(dir_path, name)
@@ -29,7 +30,7 @@ def main():
             metadata = json.load(open(path))
             expected_suffix = metadata['schema_type'] + '.json'
             if not name.endswith(expected_suffix):
-                fails[name]['suffix'] = f'Expected to end with "{expected_suffix}".'
+                fails[path]['suffix'] = f'Expected to end with "{expected_suffix}".'
                 continue
             described_by = metadata['describedBy']
             schema_url = urlparse(described_by)
@@ -41,14 +42,15 @@ def main():
             try:
                 validate(instance=metadata, schema=schema)
             except (ValidationError, SchemaError) as e:
-                fails[name]['hca'] = e
+                fails[path]['hca'] = e
             try:
                 validate(instance=metadata, schema=hubmap_schema)
             except (ValidationError, SchemaError) as e:
-                fails[name]['hubmap'] = e
+                fails[path]['hubmap'] = e
 
     if fails:
-        print(fails)
+        PrettyPrinter().pprint(dict(fails))
+        print('FAIL!')
         exit(1)
     else:
         print('PASS!')


### PR DESCRIPTION
I think we'll want to pin the version of the HCA schemas that we accept: The code downstream will be looking for particular fields in particular places. Since I think we'll be creating the JSON in the first place, this shouldn't be a huge impediment.

Fix #4 (though I expect this to grow.)