### PR TITLE
Remove unused directories

### DIFF
--- a/workflows/lightsheet/outputs/.gitignore
+++ b/workflows/lightsheet/outputs/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/workflows/seqfish/outputs/.gitignore
+++ b/workflows/seqfish/outputs/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/workflows/vanderbilt-af/outputs/.gitignore
+++ b/workflows/vanderbilt-af/outputs/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
These directories were left over from an earlier version: Now there is an `outputs-*` for each stage of processing.